### PR TITLE
chore: support spawning multiple storage-calculator pods

### DIFF
--- a/internal/storage/main.go
+++ b/internal/storage/main.go
@@ -2,22 +2,13 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/uselagoon/storage-calculator/internal/broker"
 
-	ns "github.com/uselagoon/machinery/utils/namespace"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -83,245 +74,29 @@ func (c *Calculator) Calculate() {
 		return
 	}
 	for _, namespace := range namespaces.Items {
-		opLog.Info(fmt.Sprintf("calculating storage for namespace %s", namespace.ObjectMeta.Name))
-		p1, _ := labels.NewRequirement("lagoon.sh/storageCalculator", "in", []string{"true"})
-		labelRequirements := []labels.Requirement{}
-		labelRequirements = append(labelRequirements, *p1)
-		podListOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
-			client.InNamespace(namespace.ObjectMeta.Name),
-			client.MatchingLabelsSelector{
-				Selector: labels.NewSelector().Add(labelRequirements...),
-			},
-		})
-		pods := &corev1.PodList{}
-		if err := c.Client.List(ctx, pods, podListOption); err != nil {
-			opLog.Error(err, fmt.Sprintf("error getting running pvcs for namespace %s", namespace.ObjectMeta.Name))
-		}
-		for _, pod := range pods.Items {
-			c.cleanup(ctx, opLog, &pod)
-		}
-		listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
-			client.InNamespace(namespace.ObjectMeta.Name),
-		})
-		pvcs := &corev1.PersistentVolumeClaimList{}
-		if err := c.Client.List(ctx, pvcs, listOption); err != nil {
-			opLog.Error(err, fmt.Sprintf("error getting running pvcs for namespace %s", namespace.ObjectMeta.Name))
-		} else {
-			// check for ignore regex configuration
-			ignoreRegex := c.IgnoreRegex
-			if value, ok := namespace.ObjectMeta.Labels["lagoon.sh/storageCalculatorIgnoreRegex"]; ok {
-				ignoreRegex = value
-			}
-			environmentID := 0
-			if value, ok := namespace.ObjectMeta.Labels["lagoon.sh/environmentId"]; ok {
-				eBytes := strings.TrimSpace(value)
-				environmentID, _ = strconv.Atoi(eBytes)
-			}
-			// create place to store storage claim sizes
-			storData := ActionData{}
-
-			if len(pvcs.Items) == 0 {
-				storData.Claims = append(storData.Claims, StorageClaim{
-					Environment:          environmentID,
-					PersisteStorageClaim: "none",
-					BytesUsed:            0,
-				})
-				actionData := ActionEvent{
-					Type:      "updateEnvironmentStorage",
-					EventType: "environmentStorage",
-					Data:      storData,
-				}
-				// send the calculated storage result to the api @TODO
-				opLog.Info(fmt.Sprintf("no volumes in %s: %v", namespace.ObjectMeta.Name, actionData))
-				// marshal and publish the result to actions-handler
-				ad, _ := json.Marshal(actionData)
-				if err := c.MQ.Publish("lagoon-actions", ad); err != nil {
-					opLog.Error(err, "error publishing message to mq")
-					continue
-				}
-				// no pvcs in this namespace, continue to the next one
-				continue
-			}
-			volumeMounts := []corev1.VolumeMount{}
-			volumes := []corev1.Volume{}
-			// define volume mounts
-			for _, pvc := range pvcs.Items {
-				// check if the specified pvc is to be ignored
-				if ignoreRegex != "" {
-					match, _ := regexp.MatchString(ignoreRegex, pvc.ObjectMeta.Name)
-					if match {
-						// this pvc is not to be calculated
-						continue
-					}
-				}
-				// defined the volumes and mounts
-				volumeMounts = append(volumeMounts, corev1.VolumeMount{
-					Name:      pvc.ObjectMeta.Name,
-					MountPath: fmt.Sprintf("/storage/%s", pvc.ObjectMeta.Name),
-				})
-				volumes = append(volumes, corev1.Volume{
-					Name: pvc.ObjectMeta.Name,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvc.ObjectMeta.Name,
-							ReadOnly:  true,
-						},
-					},
-				})
-			}
-			// define the storage-calculator pod
-			podName := fmt.Sprintf("storage-calculator-%s", ns.RandString(8))
-			storagePod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace.ObjectMeta.Name,
-					Labels: map[string]string{
-						"lagoon.sh/storageCalculator": "true",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:         "storage-calculator",
-							Image:        c.CalculatorImage,
-							Command:      []string{"sh", "-c", "while sleep 3600; do :; done"},
-							VolumeMounts: volumeMounts,
-							EnvFrom: []corev1.EnvFromSource{
-								corev1.EnvFromSource{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "lagoon-env",
-										},
-									},
-								},
-							},
-						},
-					},
-					Volumes: volumes,
-				},
-			}
-
-			opLog.Info(fmt.Sprintf("creating storage-calculator pod %s/%s", namespace.ObjectMeta.Name, podName))
-			if err := c.Client.Create(ctx, storagePod); err != nil {
-				opLog.Error(err, fmt.Sprintf("error creating storage-calculator pod %s/%s", namespace.ObjectMeta.Name, podName))
-				continue
-			}
-			// wait for it to be running
-			if err := wait.PollImmediateWithContext(ctx, time.Second, 90*time.Second,
-				c.hasRunningPod(ctx, namespace.ObjectMeta.Name, podName)); err != nil {
-				opLog.Error(err, fmt.Sprintf("error starting storage-calculator pod %s/%s", namespace.ObjectMeta.Name, podName))
-				c.cleanup(ctx, opLog, storagePod)
-				continue
-			}
-
-			// exec in and check the volumes are mounted
-			var stdin io.Reader
-			_, _, err := execPod(
-				podName,
-				namespace.ObjectMeta.Name,
-				[]string{"/bin/sh", "-c", "ls /storage"},
-				stdin,
-				false,
-			)
-			if err != nil {
-				opLog.Error(err, fmt.Sprintf("error checking storage-calculator pod %s/%s for volumes", namespace.ObjectMeta.Name, podName))
-				c.cleanup(ctx, opLog, storagePod)
-				continue
-			}
-
-			// check pvcs for their sizes
-			for _, pvc := range pvcs.Items {
-				// check if the specified pvc is to be ignored
-				if ignoreRegex != "" {
-					match, _ := regexp.MatchString(ignoreRegex, pvc.ObjectMeta.Name)
-					if match {
-						// this pvc is not to be calculated
-						continue
-					}
-				}
-				var stdin io.Reader
-				pvcValue, _, err := execPod(
-					podName,
-					namespace.ObjectMeta.Name,
-					[]string{"/bin/sh", "-c", fmt.Sprintf("du -s /storage/%s | cut -f1", pvc.ObjectMeta.Name)},
-					stdin,
-					false,
-				)
-				if err != nil {
-					opLog.Error(err, fmt.Sprintf("error checking storage-calculator pod %s/%s for pvc %s size", namespace.ObjectMeta.Name, podName, pvc.ObjectMeta.Name))
-					c.cleanup(ctx, opLog, storagePod)
-					continue
-				}
-				pBytes := strings.TrimSpace(pvcValue)
-				pBytesInt, _ := strconv.Atoi(pBytes)
-				storData.Claims = append(storData.Claims, StorageClaim{
-					Environment:          environmentID,
-					PersisteStorageClaim: pvc.ObjectMeta.Name,
-					BytesUsed:            pBytesInt,
-				})
-			}
-			mdbValue, _, err := execPod(
-				podName,
-				namespace.ObjectMeta.Name,
-				[]string{"/bin/sh", "-c", `if [ "$MARIADB_HOST" ]; then mysql -N -s -h $MARIADB_HOST -u$MARIADB_USERNAME -p$MARIADB_PASSWORD -P$MARIADB_PORT -e 'SELECT ROUND(SUM(data_length + index_length) / 1024, 0) FROM information_schema.tables'; else exit 1; fi`},
-				stdin,
-				false,
-			)
-			if err != nil {
-				opLog.Error(err, fmt.Sprintf("error checking storage-calculator pod %s/%s for mariadb size", namespace.ObjectMeta.Name, podName))
-				c.cleanup(ctx, opLog, storagePod)
-				continue
-			}
-			if mdbValue != "" {
-				mBytes := strings.TrimSpace(mdbValue)
-				mBytesInt, _ := strconv.Atoi(mBytes)
-				storData.Claims = append(storData.Claims, StorageClaim{
-					Environment:          environmentID,
-					PersisteStorageClaim: "mariadb",
-					BytesUsed:            mBytesInt,
-				})
-				mergePatch, _ := json.Marshal(map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]string{
-							"lagoon/storage-mariadb":    mBytes,
-							"lagoon.sh/storage-mariadb": mBytes,
-						},
-					},
-				})
-				if err := c.Client.Patch(ctx, &namespace, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-					opLog.Error(err, fmt.Sprintf("error patching %s", namespace.ObjectMeta.Name))
-					c.cleanup(ctx, opLog, storagePod)
-					continue
-				}
-			}
-			c.cleanup(ctx, opLog, storagePod)
-			// send the calculated storage result to the api @TODO
-
-			actionData := ActionEvent{
-				Type:      "updateEnvironmentStorage",
-				EventType: "environmentStorage",
-				Data:      storData,
-			}
-			opLog.Info(fmt.Sprintf("volumes from storage-calculator pod %s/%s: %v", namespace.ObjectMeta.Name, podName, actionData))
-			// marshal and publish the result to actions-handler
-			ad, _ := json.Marshal(actionData)
-			if err := c.MQ.Publish("lagoon-actions", ad); err != nil {
-				opLog.Error(err, "error publishing message to mq")
-				continue
-			}
+		err := c.checkVolumesCreatePods(ctx, opLog, namespace)
+		if err != nil {
+			continue
 		}
 	}
 }
 
-func (c *Calculator) cleanup(ctx context.Context, opLog logr.Logger, storagePod *corev1.Pod) {
+func (c *Calculator) cleanup(
+	ctx context.Context,
+	opLog logr.Logger,
+	storagePod *corev1.Pod,
+) {
 	opLog.Info(fmt.Sprintf("cleaning up storage-calculator pod %s/%s", storagePod.ObjectMeta.Namespace, storagePod.ObjectMeta.Name))
 	if err := c.Client.Delete(ctx, storagePod); err != nil {
 		opLog.Error(err, fmt.Sprintf("error deleting storage-calculator pod %s/%s", storagePod.ObjectMeta.Namespace, storagePod.ObjectMeta.Name))
 	}
 }
 
-func (c *Calculator) hasRunningPod(ctx context.Context,
-	namespace, pod string) wait.ConditionWithContextFunc {
+func (c *Calculator) hasRunningPod(
+	ctx context.Context,
+	namespace,
+	pod string,
+) wait.ConditionWithContextFunc {
 	return func(context.Context) (bool, error) {
 		storagePod := &corev1.Pod{}
 		if err := c.Client.Get(ctx, types.NamespacedName{
@@ -335,4 +110,19 @@ func (c *Calculator) hasRunningPod(ctx context.Context,
 		}
 		return storagePod.Status.Phase == "Running", nil
 	}
+}
+
+func unique(slice []string) []string {
+	// create a map with all the values as key
+	uniqMap := make(map[string]struct{})
+	for _, v := range slice {
+		uniqMap[v] = struct{}{}
+	}
+
+	// turn the map keys into a slice
+	uniqSlice := make([]string, 0, len(uniqMap))
+	for v := range uniqMap {
+		uniqSlice = append(uniqSlice, v)
+	}
+	return uniqSlice
 }

--- a/internal/storage/pod.go
+++ b/internal/storage/pod.go
@@ -1,0 +1,224 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	ns "github.com/uselagoon/machinery/utils/namespace"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// storageCalculatorPod is used to hold volume and volumemount information and node names
+// this is used for creating separate storage-calculator pods for pod volumes that may
+// be spread across multiple nodes
+type storageCalculatorPod struct {
+	NodeName     string
+	Volumes      []corev1.Volume
+	VolumeMounts []corev1.VolumeMount
+}
+
+func (c *Calculator) createStoragePod(
+	ctx context.Context,
+	opLog logr.Logger,
+	namespace corev1.Namespace,
+	spn storageCalculatorPod,
+	environmentID int,
+	ignoreRegex string,
+	checkedDatabase *bool,
+) error {
+	storData := ActionData{}
+	// define the storage-calculator pod
+	podName := fmt.Sprintf("storage-calculator-%s", ns.RandString(8))
+	storagePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace.ObjectMeta.Name,
+			Labels: map[string]string{
+				"lagoon.sh/storageCalculator": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:         "storage-calculator",
+					Image:        c.CalculatorImage,
+					Command:      []string{"sh", "-c", "while sleep 3600; do :; done"},
+					VolumeMounts: spn.VolumeMounts,
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "lagoon-env",
+								},
+							},
+						},
+					},
+				},
+			},
+			Volumes: spn.Volumes,
+		},
+	}
+
+	// if the storage pod has to be assigned to a specific node due to ReadWriteOnce, set the nodename here
+	if spn.NodeName != "" {
+		storagePod.Spec.NodeName = spn.NodeName
+	} else {
+		// otherwise we can try and set this to start on spot instances if they are existing
+		storagePod.Spec.Affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+					{
+						Preference: corev1.NodeSelectorTerm{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "lagoon.sh/spot",
+									Operator: corev1.NodeSelectorOpExists,
+								},
+							},
+						},
+						Weight: 1,
+					},
+				},
+			},
+		}
+		storagePod.Spec.Tolerations = []corev1.Toleration{
+			{
+				Key:      "lagoon.sh/spot",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectPreferNoSchedule,
+			}, {
+				Key:      "lagoon.sh/spot",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+	}
+
+	// create the pod in the cluster
+	opLog.Info(fmt.Sprintf("creating storage-calculator pod %s/%s", namespace.ObjectMeta.Name, podName))
+	if err := c.Client.Create(ctx, storagePod); err != nil {
+		return fmt.Errorf("error creating storage-calculator pod %s/%s: %v", namespace.ObjectMeta.Name, podName, err)
+	}
+
+	// wait for it to be running, or time out waiting to start the pod
+	if err := wait.PollImmediateWithContext(ctx, time.Second, 90*time.Second,
+		c.hasRunningPod(ctx, namespace.ObjectMeta.Name, podName)); err != nil {
+		c.cleanup(ctx, opLog, storagePod)
+		return fmt.Errorf("error starting storage-calculator pod %s/%s: %v", namespace.ObjectMeta.Name, podName, err)
+	}
+
+	// exec in and check the volumes are mounted firstly
+	var stdin io.Reader
+	_, _, err := execPod(
+		podName,
+		namespace.ObjectMeta.Name,
+		[]string{"/bin/sh", "-c", "ls /storage"},
+		stdin,
+		false,
+	)
+	if err != nil {
+		c.cleanup(ctx, opLog, storagePod)
+		return fmt.Errorf("error checking storage-calculator pod %s/%s for volumes: %v", namespace.ObjectMeta.Name, podName, err)
+	}
+
+	// check pvcs for their sizes
+	for _, vol := range spn.Volumes {
+		// check if the specified pvc is to be ignored
+		if ignoreRegex != "" {
+			match, _ := regexp.MatchString(ignoreRegex, vol.Name)
+			if match {
+				// this pvc is not to be calculated
+				continue
+			}
+		}
+
+		// exec into the pod and check the storage size using du
+		var stdin io.Reader
+		pvcValue, _, err := execPod(
+			podName,
+			namespace.ObjectMeta.Name,
+			[]string{"/bin/sh", "-c", fmt.Sprintf("du -s /storage/%s | cut -f1", vol.Name)},
+			stdin,
+			false,
+		)
+		if err != nil {
+			c.cleanup(ctx, opLog, storagePod)
+			return fmt.Errorf("error checking storage-calculator pod %s/%s for pvc %s size: %v", namespace.ObjectMeta.Name, podName, vol.Name, err)
+		}
+		pBytes := strings.TrimSpace(pvcValue)
+		pBytesInt, _ := strconv.Atoi(pBytes)
+		storData.Claims = append(storData.Claims, StorageClaim{
+			Environment:          environmentID,
+			PersisteStorageClaim: vol.Name,
+			BytesUsed:            pBytesInt,
+		})
+	}
+
+	if !*checkedDatabase {
+		// this could be improved to handle more, for now this replicates existing functionality
+		// collect the size of the db size from a dbaas
+		mdbValue, _, err := execPod(
+			podName,
+			namespace.ObjectMeta.Name,
+			[]string{"/bin/sh", "-c", `if [ "$MARIADB_HOST" ]; then mysql -N -s -h $MARIADB_HOST -u$MARIADB_USERNAME -p$MARIADB_PASSWORD -P$MARIADB_PORT -e 'SELECT ROUND(SUM(data_length + index_length) / 1024, 0) FROM information_schema.tables'; else exit 0; fi`},
+			stdin,
+			false,
+		)
+		if err != nil {
+			opLog.Info(fmt.Sprintf("error checking storage-calculator pod %s/%s for database size", namespace.ObjectMeta.Name, podName))
+		}
+		if mdbValue != "" {
+			// if there is a value returned that isn't "no database"
+			// then storedata against the event data
+			mBytes := strings.TrimSpace(mdbValue)
+			mBytesInt, _ := strconv.Atoi(mBytes)
+			storData.Claims = append(storData.Claims, StorageClaim{
+				Environment:          environmentID,
+				PersisteStorageClaim: "mariadb",
+				BytesUsed:            mBytesInt,
+			})
+			// and attempt to patch the namespace with the labels
+			mergePatch, _ := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]string{
+						"lagoon/storage-mariadb":    mBytes,
+						"lagoon.sh/storage-mariadb": mBytes,
+					},
+				},
+			})
+			if err := c.Client.Patch(ctx, &namespace, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
+				c.cleanup(ctx, opLog, storagePod)
+				return fmt.Errorf("error patching namespace %s: %v", namespace.ObjectMeta.Name, err)
+			}
+		}
+		// let the process know that we already checked the database so any additional storage-calculator pods for this namespace
+		// don't attempt to check it again
+		*checkedDatabase = true
+	}
+	c.cleanup(ctx, opLog, storagePod)
+
+	// send the calculated storage result to the api
+	actionData := ActionEvent{
+		Type:      "updateEnvironmentStorage",
+		EventType: "environmentStorage",
+		Data:      storData,
+	}
+	opLog.Info(fmt.Sprintf("volumes from storage-calculator pod %s/%s: %v", namespace.ObjectMeta.Name, podName, actionData))
+	// marshal and publish the result to actions-handler
+	ad, _ := json.Marshal(actionData)
+	if err := c.MQ.Publish("lagoon-actions", ad); err != nil {
+		return fmt.Errorf("error publishing message to mq: %v", err)
+	}
+	return nil
+}

--- a/internal/storage/volumes.go
+++ b/internal/storage/volumes.go
@@ -1,0 +1,209 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (c *Calculator) checkVolumesCreatePods(
+	ctx context.Context,
+	opLog logr.Logger,
+	namespace corev1.Namespace,
+) error {
+	opLog.Info(fmt.Sprintf("calculating storage for namespace %s", namespace.ObjectMeta.Name))
+
+	// check for existing storage-calculator pods that may be stuck and clean them up before proceeding
+	p1, _ := labels.NewRequirement("lagoon.sh/storageCalculator", "in", []string{"true"})
+	labelRequirements := []labels.Requirement{}
+	labelRequirements = append(labelRequirements, *p1)
+	podListOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(namespace.ObjectMeta.Name),
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(labelRequirements...),
+		},
+	})
+	pods := &corev1.PodList{}
+	if err := c.Client.List(ctx, pods, podListOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("error getting running pods for namespace %s", namespace.ObjectMeta.Name))
+	}
+	for _, pod := range pods.Items {
+		c.cleanup(ctx, opLog, &pod)
+	}
+
+	// get a list of the persistent volume claims in the namespace
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(namespace.ObjectMeta.Name),
+	})
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := c.Client.List(ctx, pvcs, listOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("error getting pvcs for namespace %s", namespace.ObjectMeta.Name))
+	} else {
+		// check for ignore regex configuration
+		ignoreRegex := c.IgnoreRegex
+		if value, ok := namespace.ObjectMeta.Labels["lagoon.sh/storageCalculatorIgnoreRegex"]; ok {
+			ignoreRegex = value
+		}
+		environmentID := 0
+		if value, ok := namespace.ObjectMeta.Labels["lagoon.sh/environmentId"]; ok {
+			eBytes := strings.TrimSpace(value)
+			environmentID, _ = strconv.Atoi(eBytes)
+		}
+		if len(pvcs.Items) == 0 {
+			// if there are no pvcs, then set the storage for none to 0
+			storData := ActionData{}
+			storData.Claims = append(storData.Claims, StorageClaim{
+				Environment:          environmentID,
+				PersisteStorageClaim: "none",
+				BytesUsed:            0,
+			})
+			actionData := ActionEvent{
+				Type:      "updateEnvironmentStorage",
+				EventType: "environmentStorage",
+				Data:      storData,
+			}
+			// send the calculated storage result to the api @TODO
+			opLog.Info(fmt.Sprintf("no volumes in %s: %v", namespace.ObjectMeta.Name, actionData))
+			// marshal and publish the result to actions-handler
+			ad, _ := json.Marshal(actionData)
+			if err := c.MQ.Publish("lagoon-actions", ad); err != nil {
+				opLog.Error(err, "error publishing message to mq")
+				return err
+			}
+			// no pvcs in this namespace, continue to the next one
+			return fmt.Errorf("no pvcs in namespace %s", namespace.ObjectMeta.Name)
+		}
+
+		// work out how many storage-calculator pods are required for this environment
+		storagePodPerNode := make(map[string]storageCalculatorPod)
+		volumeMounts := []corev1.VolumeMount{}
+		volumes := []corev1.Volume{}
+		for _, pvc := range pvcs.Items {
+			// check if the specified pvc is to be ignored
+			if ignoreRegex != "" {
+				match, _ := regexp.MatchString(ignoreRegex, pvc.ObjectMeta.Name)
+				if match {
+					// this pvc is not to be calculated
+					continue
+				}
+			}
+			// check if the volume has the accessmode of readwriteonce, if it does then try determine which node the
+			// the volume is currently mounted to
+			isRWO := false
+			for _, am := range pvc.Spec.AccessModes {
+				if am == corev1.ReadWriteOnce {
+					isRWO = true
+				}
+			}
+			if isRWO {
+				// this pvc is a rwo, check which node the volume is on
+				// if there are multiple pvcs on this node they will get appended to the node map
+				// otherwise if they are spread across multiple nodes they will get up on those specific nodes
+				podNode, err := c.collectPodsForPVC(ctx, opLog, namespace, pvc.Labels["lagoon.sh/service-type"], pvc.ObjectMeta.Name)
+				if err != nil {
+					opLog.Error(err, "error checking for node")
+				}
+				if spn, ok := storagePodPerNode[podNode]; ok {
+					// if this is the first time we are seeing the node, add the first volume to it
+					spn.VolumeMounts = append(spn.VolumeMounts, corev1.VolumeMount{
+						Name:      pvc.ObjectMeta.Name,
+						MountPath: fmt.Sprintf("/storage/%s", pvc.ObjectMeta.Name),
+					})
+					spn.Volumes = append(spn.Volumes, corev1.Volume{
+						Name: pvc.ObjectMeta.Name,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvc.ObjectMeta.Name,
+								ReadOnly:  true,
+							},
+						},
+					})
+					storagePodPerNode[podNode] = spn
+				} else {
+					// additional volumes get appended if they're on the same node as the other volumes
+					storagePodPerNode[podNode] = storageCalculatorPod{
+						NodeName: podNode,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      pvc.ObjectMeta.Name,
+								MountPath: fmt.Sprintf("/storage/%s", pvc.ObjectMeta.Name),
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: pvc.ObjectMeta.Name,
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.ObjectMeta.Name,
+										ReadOnly:  true,
+									},
+								},
+							},
+						},
+					}
+				}
+			} else {
+				// otherwise it has ReadWriteMany volume to append to the existing volumes
+				// this pod can be created on any node then
+				storagePodPerNode[namespace.ObjectMeta.Name] = storageCalculatorPod{
+					VolumeMounts: append(volumeMounts, corev1.VolumeMount{
+						Name:      pvc.ObjectMeta.Name,
+						MountPath: fmt.Sprintf("/storage/%s", pvc.ObjectMeta.Name),
+					}),
+					Volumes: append(volumes, corev1.Volume{
+						Name: pvc.ObjectMeta.Name,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvc.ObjectMeta.Name,
+								ReadOnly:  true,
+							},
+						},
+					}),
+				}
+			}
+		}
+
+		checkedDatabase := false
+		for _, spn := range storagePodPerNode {
+			if err := c.createStoragePod(ctx, opLog, namespace, spn, environmentID, ignoreRegex, &checkedDatabase); err != nil {
+				opLog.Error(err, "create storage-calculator pod error")
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Calculator) collectPodsForPVC(ctx context.Context, opLog logr.Logger, namespace corev1.Namespace, sType, cName string) (string, error) {
+	p1, _ := labels.NewRequirement("lagoon.sh/service-type", "in", []string{sType})
+	labelRequirements := []labels.Requirement{}
+	labelRequirements = append(labelRequirements, *p1)
+	podListOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(namespace.ObjectMeta.Name),
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(labelRequirements...),
+		},
+	})
+	pods := &corev1.PodList{}
+	if err := c.Client.List(ctx, pods, podListOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("error getting running pvcs for namespace %s", namespace.ObjectMeta.Name))
+		return "", fmt.Errorf("error getting running pvcs for namespace %s", namespace.ObjectMeta.Name)
+	}
+	for _, pod := range pods.Items {
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil {
+				if volume.PersistentVolumeClaim.ClaimName == cName {
+					return pod.Spec.NodeName, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("unable to find volume and node")
+}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

In some cases, a ReadWriteOnce volume could be attached to a pod that starts on different node to where the storage-calculator pod starts.

This adds support for scanning any ReadWriteOnce volumes in the namespace, checking which nodes the volumes are currently mounted to, and then creating storage-calculator pods specific for that node/volume. It will combine any ReadWriteMany volumes to one of these pods if there are multiples.

Database checks are also performed in only 1 of the pods.

---
Example 1:
* solr on node-a (RWO)
* redis-persistent on node-b (RWO)
* nginx on node-a and node-b (RWX)
* mariadb (on a DBaaS provider)

The storage-calculator will create 2 storage-calculator pods. 
* One will be spawned on node-a, the other on node-b
* The nginx volume will be added to one of these storage-calculator pods randomly since it is a RWX volume
* The mariadb size will be checked by the first storage-calculator created

---
Example 2:
* solr on node-a (RWO)
* redis-persistent on node-a (RWO)
* nginx on node-a and node-b (RWX)
* mariadb (on a DBaaS provider)

The storage-calculator will create 1 storage-calculator pods. 
* It will be spawned on node-a
* The nginx volume will be added to this single storage-calculator pod
* The mariadb size will be checked by this single storage-calculator pod