### PR TITLE
refactor: add lagoon_namespace to metrics, and change naming of bytes to kilobytes

### DIFF
--- a/internal/storage/main.go
+++ b/internal/storage/main.go
@@ -47,17 +47,19 @@ type ActionEvent struct {
 func (ae *ActionEvent) ExportMetrics(promStorage *prometheus.GaugeVec) {
 	for _, claim := range ae.Data.Claims {
 		promStorage.With(prometheus.Labels{
-			"claimenv":    strconv.Itoa(claim.Environment),
-			"claimpvc":    claim.PersisteStorageClaim,
-			"project":     ae.Meta.Project,
-			"environment": ae.Meta.Environment,
-		}).Set(float64(claim.BytesUsed))
+			"claimenv":         strconv.Itoa(claim.Environment),
+			"claimpvc":         claim.PersisteStorageClaim,
+			"project":          ae.Meta.Project,
+			"environment":      ae.Meta.Environment,
+			"lagoon_namespace": ae.Meta.Namespace,
+		}).Set(float64(claim.KiloBytesUsed))
 	}
 }
 
 type MetaData struct {
 	Project     string `json:"project"`
 	Environment string `json:"environment"`
+	Namespace   string `json:"namespace"`
 }
 
 type ActionData struct {
@@ -67,7 +69,9 @@ type ActionData struct {
 type StorageClaim struct {
 	Environment          int    `json:"environment"`
 	PersisteStorageClaim string `json:"persistentStorageClaim"`
-	BytesUsed            int    `json:"bytesUsed"`
+	//it is actually kilobytes that du outputs, this should be deprecated
+	BytesUsed     int `json:"bytesUsed"`
+	KiloBytesUsed int `json:"kiloBytesUsed"`
 }
 
 // Calculate will run the storage-calculator job.

--- a/internal/storage/pod.go
+++ b/internal/storage/pod.go
@@ -162,6 +162,7 @@ func (c *Calculator) createStoragePod(
 			Environment:          environmentID,
 			PersisteStorageClaim: vol.Name,
 			BytesUsed:            pBytesInt,
+			KiloBytesUsed:        pBytesInt,
 		})
 	}
 
@@ -187,6 +188,7 @@ func (c *Calculator) createStoragePod(
 				Environment:          environmentID,
 				PersisteStorageClaim: "mariadb",
 				BytesUsed:            mBytesInt,
+				KiloBytesUsed:        mBytesInt,
 			})
 			// and attempt to patch the namespace with the labels
 			mergePatch, _ := json.Marshal(map[string]interface{}{
@@ -214,6 +216,7 @@ func (c *Calculator) createStoragePod(
 		EventType: "environmentStorage",
 		Data:      storData,
 		Meta: MetaData{
+			Namespace:   namespace.ObjectMeta.Name,
 			Project:     namespace.ObjectMeta.Labels["lagoon.sh/project"],
 			Environment: namespace.ObjectMeta.Labels["lagoon.sh/environment"],
 		},

--- a/internal/storage/volumes.go
+++ b/internal/storage/volumes.go
@@ -64,12 +64,14 @@ func (c *Calculator) checkVolumesCreatePods(
 				Environment:          environmentID,
 				PersisteStorageClaim: "none",
 				BytesUsed:            0,
+				KiloBytesUsed:        0,
 			})
 			actionData := ActionEvent{
 				Type:      "updateEnvironmentStorage",
 				EventType: "environmentStorage",
 				Data:      storData,
 				Meta: MetaData{
+					Namespace:   namespace.ObjectMeta.Name,
 					Project:     namespace.ObjectMeta.Labels["lagoon.sh/project"],
 					Environment: namespace.ObjectMeta.Labels["lagoon.sh/environment"],
 				},

--- a/main.go
+++ b/main.go
@@ -50,10 +50,10 @@ var (
 	setupLog     = ctrl.Log.WithName("setup")
 	prom_storage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "lagoon_storage_calculator_bytes",
-			Help: "The lagoon storage calculator bytes",
+			Name: "lagoon_storage_calculator_kilobytes",
+			Help: "The lagoon storage calculator kilobytes bytes",
 		},
-		[]string{"claimenv", "claimpvc", "project", "environment"},
+		[]string{"claimenv", "claimpvc", "project", "environment", "lagoon_namespace"},
 	)
 )
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The storage calculator actually outputs size in kilobytes, not bytes. This renames the structure to be kilobytes, but retains bytes for now in the return payload as lagoon will need updates to support the change to kilobytes

It also updates the metrics to include the `lagoon_namespace` now in the metrics data