### PR TITLE
refactor: use uint64 for storage size

### DIFF
--- a/internal/storage/main.go
+++ b/internal/storage/main.go
@@ -70,8 +70,8 @@ type StorageClaim struct {
 	Environment          int    `json:"environment"`
 	PersisteStorageClaim string `json:"persistentStorageClaim"`
 	//it is actually kilobytes that du outputs, this should be deprecated
-	BytesUsed     int `json:"bytesUsed"`
-	KiloBytesUsed int `json:"kiloBytesUsed"`
+	BytesUsed     uint64 `json:"bytesUsed"`
+	KiloBytesUsed uint64 `json:"kiloBytesUsed"`
 }
 
 // Calculate will run the storage-calculator job.

--- a/internal/storage/pod.go
+++ b/internal/storage/pod.go
@@ -161,8 +161,8 @@ func (c *Calculator) createStoragePod(
 		storData.Claims = append(storData.Claims, StorageClaim{
 			Environment:          environmentID,
 			PersisteStorageClaim: vol.Name,
-			BytesUsed:            pBytesInt,
-			KiloBytesUsed:        pBytesInt,
+			BytesUsed:            uint64(pBytesInt),
+			KiloBytesUsed:        uint64(pBytesInt),
 		})
 	}
 
@@ -187,8 +187,8 @@ func (c *Calculator) createStoragePod(
 			storData.Claims = append(storData.Claims, StorageClaim{
 				Environment:          environmentID,
 				PersisteStorageClaim: "mariadb",
-				BytesUsed:            mBytesInt,
-				KiloBytesUsed:        mBytesInt,
+				BytesUsed:            uint64(mBytesInt),
+				KiloBytesUsed:        uint64(mBytesInt),
 			})
 			// and attempt to patch the namespace with the labels
 			mergePatch, _ := json.Marshal(map[string]interface{}{


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Just changes the size for storage to be a uint64