### PR TITLE
fix: remove app_id field from messagequeue config

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -40,6 +40,6 @@ func (h *MQ) Publish(queue string, message []byte) error {
 		opLog.Info(fmt.Sprintf("Failed to get async producer: %v", err))
 		return err
 	}
-	producer.Produce([]byte(fmt.Sprintf("%s", message)))
+	producer.Produce(message)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -170,7 +170,6 @@ func main() {
 				Name:     "lagoon-actions",
 				Exchange: "lagoon-actions",
 				Options: mq.Options{
-					"app_id":        lagoonAppID,
 					"delivery_mode": "2",
 					"headers":       "",
 					"content_type":  "",


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When updating the dependencies, a legacy `app_id` field was left in the configuration from a previous fork of the go-mq library which is no longer used. This caused the messaging publish to silently fail, even though there is some error handling, the error appears to happen deeper and is absorbed silently. 
