### PR TITLE
feat: add safe-to-evict=false to storage-calculator pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 	var mqWorkers int
 	var rabbitRetryInterval int
 	var exportPrometheusMetrics bool
+	var clusterAutoscalerEvict bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
@@ -129,6 +130,9 @@ func main() {
 	flag.StringVar(&storageCalculatorImage, "storage-calculator-image", "uselagoon/database-tools",
 		"The image to use for storage-calculator pods.")
 	flag.BoolVar(&exportPrometheusMetrics, "prometheus-metrics", false, "Export prometheus metrics.")
+	// Flag to control the setting for the label cluster-autoscaler.kubernetes.io/safe-to-evict on pods, defaults to false to avoid calculation pods
+	flag.BoolVar(&clusterAutoscalerEvict, "enable-cluster-autoscaler-eviction", false,
+		"Flag to enable cluster autoscaler eviction on storage-calculator pods, defaults to false to avoid evicting running calculators")
 
 	opts := zap.Options{
 		Development: true,
@@ -260,14 +264,15 @@ func main() {
 
 	// setup the handler with the k8s and lagoon clients
 	storage := &storage.Calculator{
-		Client:          mgr.GetClient(),
-		MQ:              messaging,
-		Log:             ctrl.Log,
-		IgnoreRegex:     ignoreRegex,
-		CalculatorImage: storageCalculatorImage,
-		Debug:           false,
-		ExportMetrics:   exportPrometheusMetrics,
-		PromStorage:     prom_storage,
+		Client:                 mgr.GetClient(),
+		MQ:                     messaging,
+		Log:                    ctrl.Log,
+		IgnoreRegex:            ignoreRegex,
+		CalculatorImage:        storageCalculatorImage,
+		Debug:                  false,
+		ExportMetrics:          exportPrometheusMetrics,
+		PromStorage:            prom_storage,
+		ClusterAutoscalerEvict: clusterAutoscalerEvict,
 	}
 	c := cron.New()
 	// add the cronjobs we need.

--- a/internal/storage/main.go
+++ b/internal/storage/main.go
@@ -30,15 +30,16 @@ import (
 
 // Calculator handles collecting storage calculator information
 type Calculator struct {
-	Client          client.Client
-	MQ              *broker.MQ
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	IgnoreRegex     string
-	CalculatorImage string
-	Debug           bool
-	ExportMetrics   bool
-	PromStorage     *prometheus.GaugeVec
+	Client                 client.Client
+	MQ                     *broker.MQ
+	Log                    logr.Logger
+	Scheme                 *runtime.Scheme
+	IgnoreRegex            string
+	CalculatorImage        string
+	Debug                  bool
+	ExportMetrics          bool
+	PromStorage            *prometheus.GaugeVec
+	ClusterAutoscalerEvict bool
 }
 
 type ActionEvent struct {

--- a/internal/storage/pod.go
+++ b/internal/storage/pod.go
@@ -206,6 +206,7 @@ func (c *Calculator) getPodSpec(
 			Labels: map[string]string{
 				"lagoon.sh/storageCalculator": "true",
 			},
+			Annotations: map[string]string{},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -216,6 +217,10 @@ func (c *Calculator) getPodSpec(
 				},
 			},
 		},
+	}
+	if !c.ClusterAutoscalerEvict {
+		// try to prevent calculator pods from being evicted by cluster autoscaler
+		storagePod.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
 	}
 
 	// Pod may need to run on specific node to mount some volumes.


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Just a small safeguard to storage-calculator pods to attempt to prevent them being evicted by cluster autoscaler events.