### PR TITLE
feat: support label on namespace to trigger calculator run

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uselagoon/storage-calculator/internal/broker"
+	"github.com/uselagoon/storage-calculator/internal/namespace"
 	"github.com/uselagoon/storage-calculator/internal/storage"
 
 	"github.com/robfig/cron/v3"
@@ -296,7 +297,15 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
+	if err = (&namespace.NamespaceReconciler{
+		Client:  mgr.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("Namespace"),
+		Scheme:  mgr.GetScheme(),
+		Storage: storage,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
+		os.Exit(1)
+	}
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/internal/namespace/namespace.go
+++ b/internal/namespace/namespace.go
@@ -1,0 +1,67 @@
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/uselagoon/storage-calculator/internal/storage"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// NamespaceReconciler reconciles namespaces for running storage calculators on demand
+type NamespaceReconciler struct {
+	client.Client
+	Log     logr.Logger
+	Scheme  *runtime.Scheme
+	Storage *storage.Calculator
+}
+
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	opLog := r.Log.WithValues("namespace", req.NamespacedName)
+
+	var namespace corev1.Namespace
+	if err := r.Get(ctx, req.NamespacedName, &namespace); err != nil {
+		return ctrl.Result{}, ignoreNotFound(err)
+	}
+
+	if val, ok := namespace.Labels["storage.lagoon.sh/calculate"]; ok && val == "true" {
+		opLog.Info(fmt.Sprintf("Running storage calculator on environment %s", namespace.Name))
+		r.Storage.CalculateNamespace(ctx, namespace, opLog)
+		nsMergePatch, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]*string{
+					"storage.lagoon.sh/calculate": nil,
+				},
+			},
+		})
+		if err := r.Patch(ctx, &namespace, client.RawPatch(types.MergePatchType, nsMergePatch)); err != nil {
+			opLog.Info(fmt.Sprintf("Error patching namespace %s -%v", namespace.Name, err))
+		}
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the watch on the namespace resource with an event filter (see predicates.go)
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		WithEventFilter(NamespacePredicates{}).
+		Complete(r)
+}
+
+// will ignore not found errors
+func ignoreNotFound(err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/internal/namespace/predicates.go
+++ b/internal/namespace/predicates.go
@@ -1,0 +1,31 @@
+package namespace
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// NamespacePredicates defines the funcs for predicates
+type NamespacePredicates struct {
+	predicate.Funcs
+}
+
+// Create we only watch for create events at this stage.
+func (NamespacePredicates) Create(e event.CreateEvent) bool {
+	return true
+}
+
+// Delete returns false if a delete event.
+func (NamespacePredicates) Delete(e event.DeleteEvent) bool {
+	return true
+}
+
+// Update returns false if a delete event.
+func (NamespacePredicates) Update(e event.UpdateEvent) bool {
+	return true
+}
+
+// Generic returns false if a delete event.
+func (NamespacePredicates) Generic(e event.GenericEvent) bool {
+	return true
+}

--- a/internal/storage/main.go
+++ b/internal/storage/main.go
@@ -101,70 +101,75 @@ func (c *Calculator) Calculate() {
 		return
 	}
 	for _, namespace := range namespaces.Items {
-		opLog.Info(fmt.Sprintf("calculating storage for namespace %s", namespace.Name))
+		c.CalculateNamespace(ctx, namespace, opLog)
+	}
+}
 
-		// Cleanup old calculator pods if they are still running.
-		p1, _ := labels.NewRequirement("lagoon.sh/storageCalculator", "in", []string{"true"})
-		labelRequirements := []labels.Requirement{}
-		labelRequirements = append(labelRequirements, *p1)
-		podListOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
-			client.InNamespace(namespace.Name),
-			client.MatchingLabelsSelector{
-				Selector: labels.NewSelector().Add(labelRequirements...),
-			},
+// Calculate will run the storage-calculator job.
+func (c *Calculator) CalculateNamespace(ctx context.Context, namespace corev1.Namespace, opLog logr.Logger) {
+	opLog.Info(fmt.Sprintf("calculating storage for namespace %s", namespace.Name))
+
+	// Cleanup old calculator pods if they are still running.
+	p1, _ := labels.NewRequirement("lagoon.sh/storageCalculator", "in", []string{"true"})
+	labelRequirements := []labels.Requirement{}
+	labelRequirements = append(labelRequirements, *p1)
+	podListOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(namespace.Name),
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(labelRequirements...),
+		},
+	})
+	pods := &corev1.PodList{}
+	if err := c.Client.List(ctx, pods, podListOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("error getting storage-calculator pods for namespace %s", namespace.Name))
+	}
+	for _, pod := range pods.Items {
+		c.cleanup(ctx, opLog, &pod)
+	}
+
+	// Calculate storage for volumes and databases.
+	volClaims, volErr := c.checkVolumesCreatePods(ctx, opLog, namespace)
+	if volErr != nil {
+		opLog.Error(volErr, "error calculating volumes")
+	}
+	dbClaims, dbErr := c.checkDatabasesCreatePods(ctx, opLog, namespace)
+	if dbErr != nil {
+		opLog.Error(dbErr, "error calculating databases")
+	}
+
+	// Report a "none" claim to differentiate between no storage used and no
+	// storage recorded (due to error or crash)
+	if (volClaims == 0 && volErr != nil) && (dbClaims == 0 && dbErr != nil) {
+		environmentID := 0
+		if value, ok := namespace.Labels["lagoon.sh/environmentId"]; ok {
+			environmentID, _ = strconv.Atoi(strings.TrimSpace(value))
+		}
+
+		storData := ActionData{}
+		storData.Claims = append(storData.Claims, StorageClaim{
+			Environment:          environmentID,
+			PersisteStorageClaim: "none",
+			KiBUsed:              0,
 		})
-		pods := &corev1.PodList{}
-		if err := c.Client.List(ctx, pods, podListOption); err != nil {
-			opLog.Error(err, fmt.Sprintf("error getting storage-calculator pods for namespace %s", namespace.Name))
+		actionData := ActionEvent{
+			Type:      "updateEnvironmentStorage",
+			EventType: "environmentStorage",
+			Data:      storData,
+			Meta: MetaData{
+				Namespace:   namespace.Name,
+				Project:     namespace.Labels["lagoon.sh/project"],
+				Environment: namespace.Labels["lagoon.sh/environment"],
+			},
 		}
-		for _, pod := range pods.Items {
-			c.cleanup(ctx, opLog, &pod)
-		}
+		opLog.Info(fmt.Sprintf("no storage used in %s: %v", namespace.Name, actionData))
 
-		// Calculate storage for volumes and databases.
-		volClaims, volErr := c.checkVolumesCreatePods(ctx, opLog, namespace)
-		if volErr != nil {
-			opLog.Error(volErr, "error calculating volumes")
-		}
-		dbClaims, dbErr := c.checkDatabasesCreatePods(ctx, opLog, namespace)
-		if dbErr != nil {
-			opLog.Error(dbErr, "error calculating databases")
+		if c.ExportMetrics {
+			actionData.ExportMetrics(c.PromStorage)
 		}
 
-		// Report a "none" claim to differentiate between no storage used and no
-		// storage recorded (due to error or crash)
-		if (volClaims == 0 && volErr != nil) && (dbClaims == 0 && dbErr != nil) {
-			environmentID := 0
-			if value, ok := namespace.Labels["lagoon.sh/environmentId"]; ok {
-				environmentID, _ = strconv.Atoi(strings.TrimSpace(value))
-			}
-
-			storData := ActionData{}
-			storData.Claims = append(storData.Claims, StorageClaim{
-				Environment:          environmentID,
-				PersisteStorageClaim: "none",
-				KiBUsed:              0,
-			})
-			actionData := ActionEvent{
-				Type:      "updateEnvironmentStorage",
-				EventType: "environmentStorage",
-				Data:      storData,
-				Meta: MetaData{
-					Namespace:   namespace.Name,
-					Project:     namespace.Labels["lagoon.sh/project"],
-					Environment: namespace.Labels["lagoon.sh/environment"],
-				},
-			}
-			opLog.Info(fmt.Sprintf("no storage used in %s: %v", namespace.Name, actionData))
-
-			if c.ExportMetrics {
-				actionData.ExportMetrics(c.PromStorage)
-			}
-
-			actionDataJson, _ := json.Marshal(actionData)
-			if err := c.MQ.Publish("lagoon-actions", actionDataJson); err != nil {
-				opLog.Error(err, "error publishing message to mq")
-			}
+		actionDataJson, _ := json.Marshal(actionData)
+		if err := c.MQ.Publish("lagoon-actions", actionDataJson); err != nil {
+			opLog.Error(err, "error publishing message to mq")
 		}
 	}
 }


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Adds support for a namespace label `storage.lagoon.sh/calculate=true` to force a storage calculator run. This can be useful for debugging